### PR TITLE
Fix cascading exceptions if env None/missing during build graph expansion

### DIFF
--- a/cobble
+++ b/cobble
@@ -172,8 +172,10 @@ def init_build_dir(args):
         print('--- message ---', file = sys.stderr)
         print(*e.cause.args, file=sys.stderr)
         print('--- outer environment ---', file=sys.stderr)
-        for k in env:
-            print(k, '=', env[k], file=sys.stderr)
+        if env is not None:
+            for k in env: print(k, '=', env[k], file=sys.stderr)
+        else:
+            print(env, file=sys.stderr)
         print('--- dependency chain ---', file=sys.stderr)
         for dt, de in e.targets[1:]:
             if de is None:


### PR DESCRIPTION
If the `env` property on a concrete target is missing or invalid an assert is thrown. The exception handling code then tries to iterate over a None object, causing a secondary exception which makes it hard to deduce what happened; https://gist.github.com/arjenroodselaar/1ddfd92fbce1c3663948414271b96972. This diff skips over trying to print the environment, resulting in the intended (and much more helpful) error message:
```
./cobble init --reinit ..
Target evaluation failed in //hdl:InitialResetTests_mkInitialResetTest
--- message ---
No environment named 'bluesim_defaultfjasdk'
--- outer environment ---
None
--- dependency chain ---
ninja: error: rebuilding 'build.ninja': subcommand failed
```