### PR TITLE
Improve exception messages for env keys

### DIFF
--- a/src/cobble/env.py
+++ b/src/cobble/env.py
@@ -92,7 +92,8 @@ def immutable_string_key(name, default = None, readout = None, help = None):
     once added to the environment does not allow the value to change.
     """
     def from_literal(lit):
-        assert isinstance(lit, str)
+        assert isinstance(lit, str), \
+            "Expected str type for immutable string, got %s" % repr(lit)
         return lit
     return EnvKey(
         name,
@@ -108,7 +109,8 @@ def overrideable_string_key(name, default = None, readout = None,
     """Makes an EnvKey with a given 'name' that will accept a single string and
     allow overrides."""
     def from_literal(lit):
-        assert isinstance(lit, str)
+        assert isinstance(lit, str), \
+            "Expected str type for overridable string, got %s" % repr(lit)
         return lit
     return EnvKey(
         name,
@@ -123,7 +125,8 @@ def overrideable_bool_key(name, readout = None, default = None, help = None):
     """Makes an EnvKey with a given 'name' that will accept a single bool and
     allow overrides."""
     def from_literal(lit):
-        assert isinstance(lit, bool)
+        assert isinstance(lit, bool), \
+            "Expected bool for overrideable bool, got %s" % repr(lit)
         return lit
     return EnvKey(
         name,
@@ -392,7 +395,11 @@ class Env(object):
                     raise Exception("delta contained unknown key %s (=%r)"
                         % (k, v))
                 v = self.rewrite(v)
-                v = key_def.from_literal(v)
+                try:
+                    v = key_def.from_literal(v)
+                except Exception as e:
+                    ee = Exception("failed to parse literal for key %s (=%r)" % (k, v))
+                    raise ee from e
                 if k in self._dict:
                     new_value = key_def.combine(self._dict[k], v)
                     if new_value is None:


### PR DESCRIPTION
This diff adds messages to some asserts deep in the env key module, as well as a try/except around literal parsing. This improves error messages from..
```
Target evaluation failed in //hdl/boards/gimlet/sequencer:ignitionlet_spi
--- traceback ---
  File "./cobble", line 248, in build
    cobble.cmd.build_targets_or_query_results(project, args.targets, args)
  File "/home/oxidecomputer/quartz/vnd/cobalt/vnd/cobble/src/cobble/cmd.py", line 108, in build_targets_or_query_results
    query_results = query_products(
  File "/home/oxidecomputer/quartz/vnd/cobalt/vnd/cobble/src/cobble/cmd.py", line 35, in query_products
    for result in concrete_products(
  File "/home/oxidecomputer/quartz/vnd/cobalt/vnd/cobble/src/cobble/target/__init__.py", line 514, in concrete_products
    _, product_map = target.evaluate(env_up)
  File "/home/oxidecomputer/quartz/vnd/cobalt/vnd/cobble/src/cobble/target/__init__.py", line 198, in evaluate
    raise ee from e
--- outer environment ---
None
--- dependency chain ---
```
.. which is not particularly helpful, to..
```
Target evaluation failed in //hdl/boards/gimlet/sequencer:ignitionlet_spi
--- message ---
failed to parse literal for key nextpnr_ice40_pack (=('--pcf-allow-unconstrained',))
--- outer environment ---
None
--- dependency chain ---
```
.. which at least provides an entry point to debugging ones BUILD file.