### PR TITLE
Use acceptable syntax since python3.3

### DIFF
--- a/src/cobble/ninja_syntax.py
+++ b/src/cobble/ninja_syntax.py
@@ -9,6 +9,7 @@ import itertools
 import textwrap
 import re
 
+
 def _escape_path(word):
     """Used to escape paths; only escapes the characters that are significant
     in a build/rule definition.  Interestingly, does *not* escape dollar signs.
@@ -23,7 +24,7 @@ def _as_iterable(input):
     """
     if isinstance(input, str):
         return [input]
-    if isinstance(input, collections.Iterable):
+    if isinstance(input, collections.abc.Iterable):
         return input
     if input is None:
         return []
@@ -128,7 +129,7 @@ class Writer(object):
             self.variable('dyndep', dyndep)
             if variables is None:
               pass
-            elif isinstance(variables, collections.Mapping):
+            elif isinstance(variables, collections.abc.Mapping):
                 for key in variables:
                     self.variable(key, variables[key])
             else:


### PR DESCRIPTION
the original syntax has been deprecated since python 3.3. In python 3.10 it is no longer supported so moving to the updated syntax.

> Deprecated since version 3.3, will be removed in version 3.9: Moved [Collections Abstract Base Classes](https://docs.python.org/3.7/library/collections.abc.html#collections-abstract-base-classes) to the [collections.abc](https://docs.python.org/3.7/library/collections.abc.html#module-collections.abc) module. For backwards compatibility, they continue to be visible in this module through Python 3.8.
https://docs.python.org/3.7/library/collections.html